### PR TITLE
Fix bucket not being automatically created in minio

### DIFF
--- a/stoat-compose.yml
+++ b/stoat-compose.yml
@@ -96,7 +96,7 @@ services:
     entrypoint: >
       /bin/sh -c "
       while ! /usr/bin/mc ready minio; do
-        /usr/bin/mc alias set minio http://stoat-minio:9000 $${MINIO_ROOT_USER:-minioautumn} $${MINIO_ROOT_PASSWORD:-minioautumn};
+        /usr/bin/mc alias set minio http://stoat-minio:9000 ${MINIO_ROOT_USER:-minioautumn} ${MINIO_ROOT_PASSWORD:-minioautumn};
         echo 'Waiting for minio...' && sleep 1;
       done;
       /usr/bin/mc mb minio/revolt-uploads || true;


### PR DESCRIPTION
The double dollar signs were preventing the username and password from being interpolated.